### PR TITLE
feat: added new banner to cfd cards

### DIFF
--- a/packages/cfd/src/Containers/cfd-compare-accounts/cfd-compare-accounts-card.tsx
+++ b/packages/cfd/src/Containers/cfd-compare-accounts/cfd-compare-accounts-card.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
+import { Text } from '@deriv/components';
+import { CFD_PLATFORMS } from '@deriv/shared';
+import { Localize } from '@deriv/translations';
 import { TModifiedTradingPlatformAvailableAccount } from 'Components/props.types';
 import CFDInstrumentsLabelHighlighted from './cfd-instruments-label-highlighted';
 import CFDCompareAccountsDescription from './cfd-compare-accounts-description';
 import CFDCompareAccountsTitleIcon from './cfd-compare-accounts-title-icon';
 import CFDCompareAccountsPlatformLabel from './cfd-compare-accounts-platform-label';
-import { Text } from '@deriv/components';
-import { CFD_PLATFORMS } from '@deriv/shared';
 
 type TCFDCompareAccountsCardProps = {
     trading_platforms: TModifiedTradingPlatformAvailableAccount;
@@ -19,7 +20,7 @@ const CFDCompareAccountsCard = ({ trading_platforms }: TCFDCompareAccountsCardPr
                 {(trading_platforms.platform === CFD_PLATFORMS.DERIVEZ ||
                     trading_platforms.platform === CFD_PLATFORMS.CTRADER) && (
                     <Text className='compare-cfd-account-card-container__banner' weight='bold' size='xs'>
-                        New!
+                        <Localize i18n_default_text='New!' />
                     </Text>
                 )}
                 <CFDCompareAccountsTitleIcon trading_platforms={trading_platforms} />

--- a/packages/cfd/src/Containers/cfd-compare-accounts/cfd-compare-accounts-card.tsx
+++ b/packages/cfd/src/Containers/cfd-compare-accounts/cfd-compare-accounts-card.tsx
@@ -4,6 +4,7 @@ import CFDInstrumentsLabelHighlighted from './cfd-instruments-label-highlighted'
 import CFDCompareAccountsDescription from './cfd-compare-accounts-description';
 import CFDCompareAccountsTitleIcon from './cfd-compare-accounts-title-icon';
 import CFDCompareAccountsPlatformLabel from './cfd-compare-accounts-platform-label';
+import { Text } from '@deriv/components';
 
 type TCFDCompareAccountsCardProps = {
     trading_platforms: TModifiedTradingPlatformAvailableAccount;
@@ -12,8 +13,11 @@ type TCFDCompareAccountsCardProps = {
 const CFDCompareAccountsCard = ({ trading_platforms }: TCFDCompareAccountsCardProps) => {
     return (
         <div className='compare-cfd-account-main-container'>
-            <CFDCompareAccountsPlatformLabel trading_platforms={trading_platforms} />
             <div className='compare-cfd-account-card-container'>
+                <CFDCompareAccountsPlatformLabel trading_platforms={trading_platforms} />
+                <Text className='compare-cfd-account-card-container__banner' weight='bold' size='xs'>
+                    New!
+                </Text>
                 <CFDCompareAccountsTitleIcon trading_platforms={trading_platforms} />
                 <CFDCompareAccountsDescription trading_platforms={trading_platforms} />
                 <CFDInstrumentsLabelHighlighted trading_platforms={trading_platforms} />

--- a/packages/cfd/src/Containers/cfd-compare-accounts/cfd-compare-accounts-card.tsx
+++ b/packages/cfd/src/Containers/cfd-compare-accounts/cfd-compare-accounts-card.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Text } from '@deriv/components';
 import { CFD_PLATFORMS } from '@deriv/shared';
 import { Localize } from '@deriv/translations';
-import { TModifiedTradingPlatformAvailableAccount, TCompareAccountsCard } from 'Components/props.types';
+import { TCompareAccountsCard } from 'Components/props.types';
 import CFDInstrumentsLabelHighlighted from './cfd-instruments-label-highlighted';
 import CFDCompareAccountsDescription from './cfd-compare-accounts-description';
 import CFDCompareAccountsTitleIcon from './cfd-compare-accounts-title-icon';

--- a/packages/cfd/src/Containers/cfd-compare-accounts/cfd-compare-accounts-card.tsx
+++ b/packages/cfd/src/Containers/cfd-compare-accounts/cfd-compare-accounts-card.tsx
@@ -5,6 +5,7 @@ import CFDCompareAccountsDescription from './cfd-compare-accounts-description';
 import CFDCompareAccountsTitleIcon from './cfd-compare-accounts-title-icon';
 import CFDCompareAccountsPlatformLabel from './cfd-compare-accounts-platform-label';
 import { Text } from '@deriv/components';
+import { CFD_PLATFORMS } from '@deriv/shared';
 
 type TCFDCompareAccountsCardProps = {
     trading_platforms: TModifiedTradingPlatformAvailableAccount;
@@ -15,9 +16,12 @@ const CFDCompareAccountsCard = ({ trading_platforms }: TCFDCompareAccountsCardPr
         <div className='compare-cfd-account-main-container'>
             <div className='compare-cfd-account-card-container'>
                 <CFDCompareAccountsPlatformLabel trading_platforms={trading_platforms} />
-                <Text className='compare-cfd-account-card-container__banner' weight='bold' size='xs'>
-                    New!
-                </Text>
+                {(trading_platforms.platform === CFD_PLATFORMS.DERIVEZ ||
+                    trading_platforms.platform === CFD_PLATFORMS.CTRADER) && (
+                    <Text className='compare-cfd-account-card-container__banner' weight='bold' size='xs'>
+                        New!
+                    </Text>
+                )}
                 <CFDCompareAccountsTitleIcon trading_platforms={trading_platforms} />
                 <CFDCompareAccountsDescription trading_platforms={trading_platforms} />
                 <CFDInstrumentsLabelHighlighted trading_platforms={trading_platforms} />

--- a/packages/cfd/src/Containers/cfd-compare-accounts/cfd-compare-accounts.scss
+++ b/packages/cfd/src/Containers/cfd-compare-accounts/cfd-compare-accounts.scss
@@ -44,13 +44,11 @@
             justify-content: center;
             align-items: center;
             padding: 1.5rem;
-            width: 13rem;
+            width: 15rem;
             height: 2rem;
-            right: -4rem;
-            top: 1rem;
             background: var(--status-transfer);
             color: var(--text-colored-background);
-            transform: rotate(45deg);
+            transform: translateX(17rem) translateY(-2rem) rotate(45deg);
         }
     }
     &-outline {

--- a/packages/cfd/src/Containers/cfd-compare-accounts/cfd-compare-accounts.scss
+++ b/packages/cfd/src/Containers/cfd-compare-accounts/cfd-compare-accounts.scss
@@ -46,8 +46,8 @@
             padding: 5px 10px;
             width: 200px;
             height: 26px;
-            right: -60px;
-            top: 25px;
+            right: -70px;
+            top: 15px;
             background: var(--status-transfer);
             color: var(--text-colored-background);
             transform: rotate(45deg);

--- a/packages/cfd/src/Containers/cfd-compare-accounts/cfd-compare-accounts.scss
+++ b/packages/cfd/src/Containers/cfd-compare-accounts/cfd-compare-accounts.scss
@@ -5,7 +5,7 @@
     &-navigation {
         display: flex;
         align-items: center;
-        gap: 8px;
+        gap: 1rem;
         cursor: pointer;
     }
     &-title {
@@ -39,15 +39,15 @@
         }
         &__banner {
             position: absolute;
-            z-index: 50;
+            z-index: 1000;
             display: flex;
             justify-content: center;
             align-items: center;
-            padding: 5px 10px;
-            width: 200px;
-            height: 26px;
-            right: -70px;
-            top: 15px;
+            padding: 1.5rem;
+            width: 13rem;
+            height: 2rem;
+            right: -4rem;
+            top: 1rem;
             background: var(--status-transfer);
             color: var(--text-colored-background);
             transform: rotate(45deg);

--- a/packages/cfd/src/Containers/cfd-compare-accounts/cfd-compare-accounts.scss
+++ b/packages/cfd/src/Containers/cfd-compare-accounts/cfd-compare-accounts.scss
@@ -29,12 +29,28 @@
         padding-right: 1rem;
     }
     &-card-container {
+        position: relative;
+        overflow: hidden;
         width: 27rem;
         border: 1px solid var(--general-hover);
-        padding: 2.4rem;
         border-radius: 2.4rem;
         &:hover {
             box-shadow: 0 2px 8px 0 var(--shadow-menu);
+        }
+        &__banner {
+            position: absolute;
+            z-index: 50;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            padding: 5px 10px;
+            width: 200px;
+            height: 26px;
+            right: -60px;
+            top: 25px;
+            background: var(--status-transfer);
+            color: var(--text-colored-background);
+            transform: rotate(45deg);
         }
     }
     &-outline {
@@ -53,12 +69,11 @@
         display: flex;
         flex-direction: column;
         gap: 0.5rem;
+        padding-top: 2rem;
         align-items: center;
     }
     &-platform-label {
         background-color: var(--header-background-mt5);
-        position: relative;
-        top: 2rem;
         padding: 0.9rem;
         border-top-left-radius: 1.4rem;
         border-top-right-radius: 1.4rem;

--- a/packages/cfd/src/Containers/cfd-compare-accounts/cfd-compare-accounts.scss
+++ b/packages/cfd/src/Containers/cfd-compare-accounts/cfd-compare-accounts.scss
@@ -39,7 +39,7 @@
         }
         &__banner {
             position: absolute;
-            z-index: 1000;
+            z-index: 1;
             display: flex;
             justify-content: center;
             align-items: center;


### PR DESCRIPTION
## Changes:

the "New!" banner is done, for demonstration purpose, it is applied on all cfd cards until derivez and ctrader is displayed
in the PR, condition is applied to only show the banner for derivez and ctrader

### Screenshots:

![image](https://github.com/hirad-deriv/deriv-app/assets/108507236/117e47c5-9fc5-43de-8f87-7526d591b49d)

