### PR TITLE
shontzu/CFDS-752/Deriv-X-Other-CFDs-Missing-the-word-Platform-and-Forex-standard/micro-should-show-Forex-only

### DIFF
--- a/packages/cfd/src/Helpers/compare-accounts-config.ts
+++ b/packages/cfd/src/Helpers/compare-accounts-config.ts
@@ -15,7 +15,10 @@ const getHighlightedIconLabel = (
     const market_type_shortcode = market_type.concat('_', trading_platforms.shortcode);
     // Forex for these: MT5 Financial Vanuatu, MT5 Financial Labuan
     const forex_label =
-        market_type_shortcode === 'financial_labuan' || market_type_shortcode === 'financial_vanuatu' || is_demo
+        market_type_shortcode === 'financial_labuan' ||
+        market_type_shortcode === 'financial_vanuatu' ||
+        is_demo ||
+        trading_platforms.platform === CFD_PLATFORMS.DXTRADE
             ? localize('Forex')
             : localize('Forex: standard/micro');
 

--- a/packages/cfd/src/Helpers/compare-accounts-config.ts
+++ b/packages/cfd/src/Helpers/compare-accounts-config.ts
@@ -15,8 +15,7 @@ const getHighlightedIconLabel = (
     const market_type_shortcode = market_type.concat('_', trading_platforms.shortcode);
     // Forex for these: MT5 Financial Vanuatu, MT5 Financial Labuan
     const forex_label =
-        market_type_shortcode === 'financial_labuan' ||
-        market_type_shortcode === 'financial_vanuatu' ||
+        ['financial_labuan', 'financial_vanuatu'].includes(market_type_shortcode) ||
         is_demo ||
         trading_platforms.platform === CFD_PLATFORMS.DXTRADE
             ? localize('Forex')

--- a/packages/cfd/src/Helpers/compare-accounts-config.ts
+++ b/packages/cfd/src/Helpers/compare-accounts-config.ts
@@ -101,7 +101,7 @@ const getPlatformLabel = (shortcode?: string) => {
     switch (shortcode) {
         case 'dxtrade':
         case 'CFDs':
-            return localize('Other CFDs');
+            return localize('Other CFDs Platform');
         case 'mt5':
         default:
             return localize('MT5 Platform');
@@ -111,7 +111,7 @@ const getPlatformLabel = (shortcode?: string) => {
 // Object to map the platform label
 const platfromsHeaderLabel = {
     mt5: localize('MT5 Platform'),
-    other_cfds: localize('Other CFDs'),
+    other_cfds: localize('Other CFDs Platform'),
 };
 
 // Get the Account Icons based on the market type


### PR DESCRIPTION
## Changes:

- [CU](https://app.clickup.com/t/20696747/CFDS-752)
- [Figma](https://www.figma.com/file/7R7ohVHbwwbI9baVqBtKGy/Release---v1.1.0---High-risk-ROW-Trader%E2%80%99s-hub-(replace-with-rebuild-file)?type=design&node-id=34249-358786&mode=design&t=RBlyB4c6VAu5c9Or-0)

### Screenshots:

Please provide some screenshots of the change.
