### PR TITLE
shontzu/CFDS-762/Mobile_Android_Demo_Real_Icon-of-Forex-and-Cryptocurrencies-have-a-different-size-and-inconsistent-as-others

### DIFF
--- a/packages/cfd/src/Containers/cfd-compare-accounts/cfd-compare-accounts.scss
+++ b/packages/cfd/src/Containers/cfd-compare-accounts/cfd-compare-accounts.scss
@@ -54,7 +54,7 @@
             box-shadow: 0 2px 8px 0 var(--shadow-menu);
         }
         @include mobile {
-            width: 17rem;
+            width: 18rem;
         }
         &__eu-clients {
             position: relative;
@@ -81,7 +81,7 @@
         padding: 2rem 2.4rem 0;
         border-radius: 2.4rem;
         @include mobile {
-            padding-top: 4.5rem;
+            padding: 5rem 1.5rem 0;
         }
     }
     &-text-container {

--- a/packages/cfd/src/Containers/cfd-compare-accounts/instruments-icon-with-label.tsx
+++ b/packages/cfd/src/Containers/cfd-compare-accounts/instruments-icon-with-label.tsx
@@ -13,14 +13,7 @@ const InstrumentsIconWithLabel = ({ icon, text, highlighted, className, is_aster
             className={className}
         >
             <TradingInstrumentsIcon icon={icon} size={24} className='trading-instruments__icon' />
-            <Text
-                as='p'
-                weight='bolder'
-                line_height='xs'
-                size='xxs'
-                align='center'
-                className='trading-instruments__text'
-            >
+            <Text as='p' weight='bolder' line_height='xs' size='xxs' align='left' className='trading-instruments__text'>
                 {text}
             </Text>
             {is_asterisk && (


### PR DESCRIPTION
## Changes:
[CU](https://app.clickup.com/t/20696747/CFDS-762)
[Figma](https://www.figma.com/file/7R7ohVHbwwbI9baVqBtKGy/Release---v1.1.0---High-risk-ROW-Trader%E2%80%99s-hub-(replace-with-rebuild-file)?type=design&node-id=34807-327832&mode=design&t=jvqaJuT4RIT7F4NZ-4)


### Screenshots:
<span align="center">
  <img src="https://github.com/hirad-deriv/deriv-app/assets/108507236/0e63e8c2-17b7-4168-b98e-8b4d32fc0512" alt="localhost binary sx_appstore_cfd-compare-acccounts(iPhone 6_7_8 Plus)" width="300" />
  <img src="https://github.com/hirad-deriv/deriv-app/assets/108507236/c50d34fb-de11-4429-8fb1-28c58c425d2c" alt="localhost binary sx_appstore_cfd-compare-acccounts(iPhone XR)" width="300" />
</span>


