### PR TITLE
shontzu/CFDS-763/Compare-CFDs-demo-account-not-be-able-to-scroll-down-full-in-mobile

### DIFF
--- a/packages/cfd/src/Containers/cfd-compare-accounts/cfd-compare-accounts.scss
+++ b/packages/cfd/src/Containers/cfd-compare-accounts/cfd-compare-accounts.scss
@@ -80,7 +80,7 @@
         padding: 4rem 2.4rem 0;
         border-radius: 2.4rem;
         @include mobile {
-            padding: 5rem 1.5rem 0;
+            padding: 7rem 1.5rem 0;
         }
     }
     &-text-container {

--- a/packages/components/src/components/cfd-compare-accounts-carousel/cfd-compare-accounts-carousel.scss
+++ b/packages/components/src/components/cfd-compare-accounts-carousel/cfd-compare-accounts-carousel.scss
@@ -8,6 +8,9 @@
         overflow: hidden;
         width: 100%;
         height: 100%;
+        @include mobile {
+            padding-bottom: 6rem;
+        }
     }
     &__container {
         backface-visibility: hidden;


### PR DESCRIPTION
## Changes:

- added padding to the bottom so on-screen navigation bar doesn't overlap with carousel
- [CU](https://app.clickup.com/t/20696747/CFDS-763)

### Screenshots:
<img src="https://github.com/hirad-deriv/deriv-app/assets/108507236/167965c0-d41e-44b0-80ca-8063abab1fab" width="200px"/>
<img src="https://github.com/hirad-deriv/deriv-app/assets/108507236/a6d21aaf-3add-4ac7-8265-d269ea7cc754" width="200px"/>