### PR TITLE
Shontzu/CFDS-829/DIEL_EU_The header of Compare CFSs accounts is differently from design 

### DIFF
--- a/packages/cfd/src/Containers/cfd-compare-accounts/cfd-compare-accounts-description.tsx
+++ b/packages/cfd/src/Containers/cfd-compare-accounts/cfd-compare-accounts-description.tsx
@@ -3,12 +3,15 @@ import classNames from 'classnames';
 import { Text } from '@deriv/components';
 import { TCompareAccountsCard } from 'Components/props.types';
 import { getJuridisctionDescription, getMarketType } from '../../Helpers/compare-accounts-config';
+import { useStore } from '@deriv/stores';
+import { localize } from '@deriv/translations';
 
 const CFDCompareAccountsDescription = ({ trading_platforms, is_demo }: TCompareAccountsCard) => {
     const market_type = getMarketType(trading_platforms);
     const market_type_shortcode = market_type.concat('_', trading_platforms.shortcode);
     const juridisction_data = getJuridisctionDescription(market_type_shortcode);
-
+    const { traders_hub } = useStore();
+    const { selected_region } = traders_hub;
     return (
         <div
             className={classNames('compare-cfd-account-text-container', {
@@ -20,21 +23,23 @@ const CFDCompareAccountsDescription = ({ trading_platforms, is_demo }: TCompareA
                     {juridisction_data.leverage}
                 </Text>
                 <Text as='p' size='xxxs' align='center'>
-                    {juridisction_data.leverage_description}
+                    {selected_region === 'Non-EU' ? juridisction_data.leverage_description : localize('Leverage')}
                 </Text>
             </div>
-            <div className='compare-cfd-account-text-container__separator'>
-                <Text as='h1' weight='bold' size='m' align='center'>
-                    {juridisction_data.spread}
-                </Text>
-                <Text as='p' size='xxxs' align='center'>
-                    {juridisction_data.spread_description}
-                </Text>
-            </div>
+            {selected_region === 'Non-EU' && (
+                <div className='compare-cfd-account-text-container__separator'>
+                    <Text as='h1' weight='bold' size='m' align='center'>
+                        {juridisction_data.spread}
+                    </Text>
+                    <Text as='p' size='xxxs' align='center'>
+                        {juridisction_data.spread_description}
+                    </Text>
+                </div>
+            )}
             {!is_demo && (
                 <React.Fragment>
                     <div className='compare-cfd-account-text-container__separator'>
-                        <Text as='h1' weight='bold' size='xxs' align='center'>
+                        <Text as='h1' weight='bold' size='xs' align='center'>
                             {juridisction_data.counterparty_company}
                         </Text>
                         <Text as='p' size='xxxs' align='center'>
@@ -42,7 +47,7 @@ const CFDCompareAccountsDescription = ({ trading_platforms, is_demo }: TCompareA
                         </Text>
                     </div>
                     <div className='compare-cfd-account-text-container__separator'>
-                        <Text as='h1' weight='bold' size='xxs' align='center'>
+                        <Text as='h1' weight='bold' size='xs' align='center'>
                             {juridisction_data.jurisdiction}
                         </Text>
                         <Text as='p' size='xxxs' align='center'>
@@ -50,9 +55,14 @@ const CFDCompareAccountsDescription = ({ trading_platforms, is_demo }: TCompareA
                         </Text>
                     </div>
                     <div className='compare-cfd-account-text-container__separator'>
-                        <Text as='h1' weight='bold' size='xxs' align='center'>
+                        <Text as='h1' weight='bold' size='xs' align='center'>
                             {juridisction_data.regulator}
                         </Text>
+                        {juridisction_data.regulator_license && (
+                            <Text as='p' size='xxxs' align='center'>
+                                {juridisction_data.regulator_license}
+                            </Text>
+                        )}
                         <Text as='p' size='xxxs' align='center'>
                             {juridisction_data.regulator_description}
                         </Text>

--- a/packages/cfd/src/Containers/cfd-compare-accounts/cfd-compare-accounts.scss
+++ b/packages/cfd/src/Containers/cfd-compare-accounts/cfd-compare-accounts.scss
@@ -20,7 +20,6 @@
 .compare-cfd-account {
     max-width: 123.2rem;
     margin: auto;
-    padding: 5rem 0;
     &-container {
         margin: 1.5rem;
         @include mobile {
@@ -54,7 +53,7 @@
             box-shadow: 0 2px 8px 0 var(--shadow-menu);
         }
         @include mobile {
-            width: 17rem;
+            width: 18rem;
         }
         &__eu-clients {
             position: relative;
@@ -78,16 +77,16 @@
     &-outline {
         display: flex;
         flex-direction: column;
-        padding: 2rem 2.4rem 0;
+        padding: 4rem 2.4rem 0;
         border-radius: 2.4rem;
         @include mobile {
-            padding-top: 4.5rem;
+            padding: 7rem 1.5rem 0;
         }
     }
     &-text-container {
-        height: 25.5rem;
+        max-height: 25.5rem;
         &--demo {
-            height: 13.5rem;
+            max-height: 13.5rem;
         }
         &__separator {
             margin: 0.9rem;

--- a/packages/cfd/src/Containers/cfd-compare-accounts/cfd-compare-accounts.tsx
+++ b/packages/cfd/src/Containers/cfd-compare-accounts/cfd-compare-accounts.tsx
@@ -19,7 +19,7 @@ const CompareCFDs = observer(() => {
     const store = useStore();
     const { client, traders_hub } = store;
     const { trading_platform_available_accounts } = client;
-    const { is_demo, is_eu_user, available_dxtrade_accounts } = traders_hub;
+    const { is_demo, is_eu_user, available_dxtrade_accounts, selected_region } = traders_hub;
 
     const sorted_available_accounts = !is_eu_user
         ? getSortedCFDAvailableAccounts(trading_platform_available_accounts)
@@ -68,9 +68,14 @@ const CompareCFDs = observer(() => {
             <h1 className='compare-cfd-header-title'>
                 <Text size='m' weight='bold' color='prominent'>
                     <Localize
-                        i18n_default_text='Compare CFDs {{demo_title}} accounts'
+                        i18n_default_text={
+                            selected_region === 'EU'
+                                ? 'Deriv MT5 CFDs {{real_title}} account'
+                                : 'Compare CFDs {{demo_title}} accounts'
+                        }
                         values={{
                             demo_title: is_demo ? localize('demo') : '',
+                            real_title: is_demo ? localize('Demo') : localize('real'),
                         }}
                     />
                 </Text>

--- a/packages/cfd/src/Containers/cfd-compare-accounts/cfd-instruments-label-highlighted.tsx
+++ b/packages/cfd/src/Containers/cfd-compare-accounts/cfd-instruments-label-highlighted.tsx
@@ -2,9 +2,13 @@ import React from 'react';
 import InstrumentsIconWithLabel from './instruments-icon-with-label';
 import { TInstrumentsIcon, TCompareAccountsCard } from 'Components/props.types';
 import { getHighlightedIconLabel } from '../../Helpers/compare-accounts-config';
+import { useStore } from '@deriv/stores';
 
 const CFDInstrumentsLabelHighlighted = ({ trading_platforms, is_demo }: TCompareAccountsCard) => {
-    const iconData: TInstrumentsIcon[] = [...getHighlightedIconLabel(trading_platforms, is_demo)];
+    const { traders_hub } = useStore();
+    const selected_region = traders_hub.selected_region;
+
+    const iconData: TInstrumentsIcon[] = [...getHighlightedIconLabel(trading_platforms, selected_region, is_demo)];
 
     return (
         <div className={'compare-cfd-account-outline'} data-testid='dt_compare_cfd_account_outline__container'>

--- a/packages/cfd/src/Helpers/compare-accounts-config.ts
+++ b/packages/cfd/src/Helpers/compare-accounts-config.ts
@@ -9,13 +9,17 @@ import {
 // Map the accounts according to the market type
 const getHighlightedIconLabel = (
     trading_platforms: TModifiedTradingPlatformAvailableAccount,
+    selected_region?: string,
     is_demo?: boolean
 ): TInstrumentsIcon[] => {
     const market_type = getMarketType(trading_platforms);
     const market_type_shortcode = market_type.concat('_', trading_platforms.shortcode);
     // Forex for these: MT5 Financial Vanuatu, MT5 Financial Labuan
     const forex_label =
-        market_type_shortcode === 'financial_labuan' || market_type_shortcode === 'financial_vanuatu' || is_demo
+        ['financial_labuan', 'financial_vanuatu'].includes(market_type_shortcode) ||
+        is_demo ||
+        trading_platforms.platform === CFD_PLATFORMS.DXTRADE ||
+        selected_region === 'EU'
             ? localize('Forex')
             : localize('Forex: standard/micro');
 
@@ -26,42 +30,69 @@ const getHighlightedIconLabel = (
                 { icon: 'Baskets', text: localize('Baskets'), highlighted: true },
                 { icon: 'DerivedFX', text: localize('Derived FX'), highlighted: true },
                 { icon: 'Stocks', text: localize('Stocks'), highlighted: false },
-                { icon: 'StockIndices', text: localize('Stock Indices'), highlighted: false },
+                { icon: 'StockIndices', text: localize('Stock indices'), highlighted: false },
                 { icon: 'Commodities', text: localize('Commodities'), highlighted: false },
                 { icon: 'Forex', text: forex_label, highlighted: false },
                 { icon: 'Cryptocurrencies', text: localize('Cryptocurrencies'), highlighted: false },
                 { icon: 'ETF', text: localize('ETF'), highlighted: false },
             ];
         case 'financial':
-            if (trading_platforms.shortcode === 'maltainvest') {
-                return [
-                    { icon: 'Synthetics', text: localize('Synthetics'), highlighted: true, is_asterisk: true },
-                    { icon: 'Forex', text: forex_label, highlighted: true },
-                    { icon: 'Stocks', text: localize('Stocks'), highlighted: true },
-                    { icon: 'StockIndices', text: localize('Stock Indices'), highlighted: true },
-                    { icon: 'Commodities', text: localize('Commodities'), highlighted: true },
-                    { icon: 'Cryptocurrencies', text: localize('Cryptocurrencies'), highlighted: true },
-                ];
+            switch (trading_platforms.shortcode) {
+                case 'maltainvest':
+                    return [
+                        { icon: 'Synthetics', text: localize('Synthetics'), highlighted: true, is_asterisk: true },
+                        { icon: 'Forex', text: forex_label, highlighted: true },
+                        { icon: 'Stocks', text: localize('Stocks'), highlighted: true },
+                        { icon: 'StockIndices', text: localize('Stock Indices'), highlighted: true },
+                        { icon: 'Commodities', text: localize('Commodities'), highlighted: true },
+                        { icon: 'Cryptocurrencies', text: localize('Cryptocurrencies'), highlighted: true },
+                    ];
+                case 'labuan':
+                    return [
+                        { icon: 'Synthetics', text: localize('Synthetics'), highlighted: false },
+                        { icon: 'Baskets', text: localize('Baskets'), highlighted: false },
+                        { icon: 'DerivedFX', text: localize('Derived FX'), highlighted: false },
+                        { icon: 'Stocks', text: localize('Stocks'), highlighted: false },
+                        { icon: 'StockIndices', text: localize('Stock Indices'), highlighted: false },
+                        { icon: 'Commodities', text: localize('Commodities'), highlighted: false },
+                        { icon: 'Forex', text: forex_label, highlighted: true },
+                        { icon: 'Cryptocurrencies', text: localize('Cryptocurrencies'), highlighted: true },
+                        { icon: 'ETF', text: localize('ETF'), highlighted: true },
+                    ];
+                default:
+                    return [
+                        { icon: 'Synthetics', text: localize('Synthetics'), highlighted: false },
+                        { icon: 'Baskets', text: localize('Baskets'), highlighted: false },
+                        { icon: 'DerivedFX', text: localize('Derived FX'), highlighted: false },
+                        { icon: 'Stocks', text: localize('Stocks'), highlighted: true },
+                        { icon: 'StockIndices', text: localize('Stock Indices'), highlighted: true },
+                        { icon: 'Commodities', text: localize('Commodities'), highlighted: true },
+                        { icon: 'Forex', text: forex_label, highlighted: true },
+                        { icon: 'Cryptocurrencies', text: localize('Cryptocurrencies'), highlighted: true },
+                        { icon: 'ETF', text: localize('ETF'), highlighted: true },
+                    ];
             }
-            return [
-                { icon: 'Synthetics', text: localize('Synthetics'), highlighted: false },
-                { icon: 'Baskets', text: localize('Baskets'), highlighted: false },
-                { icon: 'DerivedFX', text: localize('Derived FX'), highlighted: false },
-                { icon: 'Stocks', text: localize('Stocks'), highlighted: true },
-                { icon: 'StockIndices', text: localize('Stock Indices'), highlighted: true },
-                { icon: 'Commodities', text: localize('Commodities'), highlighted: true },
-                { icon: 'Forex', text: forex_label, highlighted: true },
-                { icon: 'Cryptocurrencies', text: localize('Cryptocurrencies'), highlighted: true },
-                { icon: 'ETF', text: localize('ETF'), highlighted: true },
-            ];
         case 'all':
         default:
+            if (trading_platforms.platform === 'mt5') {
+                return [
+                    { icon: 'Synthetics', text: localize('Synthetics'), highlighted: true },
+                    { icon: 'Baskets', text: localize('Baskets'), highlighted: false },
+                    { icon: 'DerivedFX', text: localize('Derived FX'), highlighted: true },
+                    { icon: 'Stocks', text: localize('Stocks'), highlighted: true },
+                    { icon: 'StockIndices', text: localize('Stock indices'), highlighted: true },
+                    { icon: 'Commodities', text: localize('Commodities'), highlighted: true },
+                    { icon: 'Forex', text: forex_label, highlighted: true },
+                    { icon: 'Cryptocurrencies', text: localize('Cryptocurrencies'), highlighted: true },
+                    { icon: 'ETF', text: localize('ETF'), highlighted: true },
+                ];
+            }
             return [
                 { icon: 'Synthetics', text: localize('Synthetics'), highlighted: true },
                 { icon: 'Baskets', text: localize('Baskets'), highlighted: true },
                 { icon: 'DerivedFX', text: localize('Derived FX'), highlighted: true },
                 { icon: 'Stocks', text: localize('Stocks'), highlighted: true },
-                { icon: 'StockIndices', text: localize('Stock Indices'), highlighted: true },
+                { icon: 'StockIndices', text: localize('Stock indices'), highlighted: true },
                 { icon: 'Commodities', text: localize('Commodities'), highlighted: true },
                 { icon: 'Forex', text: forex_label, highlighted: true },
                 { icon: 'Cryptocurrencies', text: localize('Cryptocurrencies'), highlighted: true },
@@ -101,7 +132,7 @@ const getPlatformLabel = (shortcode?: string) => {
     switch (shortcode) {
         case 'dxtrade':
         case 'CFDs':
-            return localize('Other CFDs');
+            return localize('Other CFDs Platform');
         case 'mt5':
         default:
             return localize('MT5 Platform');
@@ -111,7 +142,7 @@ const getPlatformLabel = (shortcode?: string) => {
 // Object to map the platform label
 const platfromsHeaderLabel = {
     mt5: localize('MT5 Platform'),
-    other_cfds: localize('Other CFDs'),
+    other_cfds: localize('Other CFDs Platform'),
 };
 
 // Get the Account Icons based on the market type
@@ -149,15 +180,16 @@ const getHeaderColor = (shortcode: string) => {
 // Config for different Jurisdictions
 const cfd_config = () => ({
     leverage: '1:1000',
-    leverage_description: localize('Maximum Leverage'),
+    leverage_description: localize('Maximum leverage'),
     spread: '0.5 pips',
-    spread_description: localize('Spread from'),
+    spread_description: localize('Spreads from'),
     counterparty_company: 'Deriv (SVG) LLC',
     counterparty_company_description: localize('Counterparty company'),
     jurisdiction: 'St. Vincent & Grenadines',
     jurisdiction_description: localize('Jurisdiction'),
     regulator: localize('Financial Commission'),
     regulator_description: localize('Regulator/External dispute resolution'),
+    regulator_license: '',
 });
 
 // Map the Jurisdictions with the config
@@ -166,6 +198,7 @@ const getJuridisctionDescription = (shortcode: string) => {
         counterparty_company: string,
         jurisdiction: string,
         regulator: string,
+        regulator_license: string | undefined,
         regulator_description: string,
         leverage: string = cfd_config().leverage
     ) => ({
@@ -173,6 +206,7 @@ const getJuridisctionDescription = (shortcode: string) => {
         counterparty_company,
         jurisdiction,
         regulator,
+        regulator_license,
         regulator_description,
         leverage,
     });
@@ -183,13 +217,15 @@ const getJuridisctionDescription = (shortcode: string) => {
                 'Deriv (BVI) Ltd',
                 'British Virgin Islands',
                 localize('British Virgin Islands Financial Services Commission'),
-                localize('(License no. SIBA/L/18/1114) Regulator/External dispute Resolution')
+                localize('(License no. SIBA/L/18/1114)'),
+                localize('Regulator/External dispute Resolution')
             );
         case 'synthetic_vanuatu':
             return createDescription(
                 'Deriv (V) Ltd',
                 'Vanuatu',
                 localize('Vanuatu Financial Services Commission'),
+                '',
                 localize('Regulator/External dispute resolution')
             );
         case 'financial_bvi':
@@ -197,13 +233,15 @@ const getJuridisctionDescription = (shortcode: string) => {
                 'Deriv (BVI) Ltd',
                 'British Virgin Islands',
                 localize('British Virgin Islands Financial Services Commission'),
-                localize('(License no. SIBA/L/18/1114) Regulator/External Dispute Resolution')
+                localize('(License no. SIBA/L/18/1114)'),
+                localize('Regulator/External dispute resolution')
             );
         case 'financial_vanuatu':
             return createDescription(
                 'Deriv (V) Ltd',
                 'Vanuatu',
                 localize('Vanuatu Financial Services Commission'),
+                '',
                 localize('Regulator/External Dispute Resolution')
             );
         case 'financial_labuan':
@@ -211,7 +249,8 @@ const getJuridisctionDescription = (shortcode: string) => {
                 'Deriv (FX) Ltd',
                 'Labuan',
                 localize('Labuan Financial Services Authority'),
-                localize('(licence no. MB/18/0024) Regulator/External Dispute Resolution'),
+                localize('(licence no. MB/18/0024)'),
+                localize('Regulator/External Dispute Resolution'),
                 '1:100'
             );
         case 'financial_maltainvest':
@@ -220,7 +259,8 @@ const getJuridisctionDescription = (shortcode: string) => {
                 'Malta',
                 localize('Financial Commission'),
                 localize('Regulated by the Malta Financial Services Authority (MFSA) (licence no. IS/70156)'),
-                '1:30'
+                '',
+                'Up to 1:30'
             );
         // Dxtrade
         case 'all_':


### PR DESCRIPTION
## Changes:

|      Account       |              Compare Accounts Page Header                |
|:------------------:|:--------------------------------------:|
|     idcr demo      |     Compare CFDs demo account          |
|     idcr real      |     Compare CFDs accounts              |
|     esmf demo      |     Deriv Mt5 CFDs Demo account        |
|     esmf real      |     Deriv MT5 CFDs real account        |
|     zacr demo      |     Compare CFDs demo account          |
| zacr real   |     non-eu: Compare CFDs accounts  <br />    eu: Deriv MT5 CFDs real account        |

### Screenshots:

<img src="https://github.com/binary-com/deriv-app/assets/108507236/d191e62e-a16e-4d48-8007-e4ac8f68fcc6" width="400" alt="esmf-demo">
<img src="https://github.com/binary-com/deriv-app/assets/108507236/e7db8f3b-e322-4bbd-92a7-d959911ebc7b" width="400" alt="esmf-real zacr-eu-real">
<img src="https://github.com/binary-com/deriv-app/assets/108507236/e29d2478-45ac-47fd-ab34-a0754c4c0264" width="400" alt="idcr-demo zacr-demo">
<img src="https://github.com/binary-com/deriv-app/assets/108507236/c20c3a20-4451-4dd7-9ce2-4bebe99523e1" width="400" alt="idcr-real zacr-non-eu-real">
